### PR TITLE
add OOMKilled filter

### DIFF
--- a/internal/internal.go
+++ b/internal/internal.go
@@ -14,7 +14,6 @@ package internal
 
 import (
 	"bytes"
-	"encoding/json"
 	"fmt"
 	"io/ioutil"
 	"os"
@@ -85,7 +84,13 @@ func Run() error { //nolint:funlen,cyclop
 		item = append(item, podName)
 		item = append(item, result.ContainerName)
 		item = append(item, formattedResources.MemoryRequest)
-		item = append(item, formattedResources.MemoryLimit)
+
+		if formattedResources.OOMKilled {
+			item = append(item, fmt.Sprintf("%s OOMKilled", formattedResources.MemoryLimit))
+		} else {
+			item = append(item, formattedResources.MemoryLimit)
+		}
+
 		item = append(item, formattedResources.CPURequest)
 		item = append(item, formattedResources.CPULimit)
 
@@ -98,12 +103,7 @@ func Run() error { //nolint:funlen,cyclop
 		}
 
 		if *config.Get().ShowDebugJSON {
-			info, err := json.Marshal(result)
-			if err != nil {
-				return errors.Wrap(err, "error marshalling result")
-			}
-
-			item = append(item, string(info))
+			item = append(item, result.String())
 		}
 
 		fmt.Fprintln(w, strings.Join(item, "\t"))

--- a/pkg/api/api.go
+++ b/pkg/api/api.go
@@ -125,7 +125,11 @@ func GetPodResources() ([]*types.PodResources, error) { //nolint: funlen,cyclop,
 				showResult = true
 			}
 
-			if !*config.Get().NoMemoryRequest && !*config.Get().NoCPURequest && len(*config.Get().Filter) == 0 {
+			if *config.Get().OOMKilled && item.OOMKilled {
+				showResult = true
+			}
+
+			if !*config.Get().NoMemoryRequest && !*config.Get().NoCPURequest && !*config.Get().OOMKilled && len(*config.Get().Filter) == 0 { //nolint:lll
 				showResult = true
 			}
 

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -30,6 +30,7 @@ type AppConfig struct {
 	Filter               *string
 	ShowQoS              *bool
 	ShowSafeToEvict      *bool
+	OOMKilled            *bool
 	NoCPURequest         *bool
 	NoMemoryRequest      *bool
 	PrometheusURL        *string
@@ -63,6 +64,7 @@ var appConfig = &AppConfig{
 	PodLabelSelector:     flag.String("podLabelSelector", "", "pod label selector"),
 	ShowQoS:              flag.Bool("ShowQoS", false, "show QoS"),
 	ShowSafeToEvict:      flag.Bool("ShowSafeToEvict", false, "show Autoscaler safeToEvict"),
+	OOMKilled:            flag.Bool("OOMKilled", false, "show only if container OOMKilled"),
 	NoCPURequest:         flag.Bool("NoCPURequest", false, "show only when cpu request is not set"),
 	NoMemoryRequest:      flag.Bool("NoMemoryRequest", false, "show only when memory request is not set"),
 	PrometheusURL:        flag.String("prometheus.url", "", "prometheus url"),

--- a/pkg/types/types.go
+++ b/pkg/types/types.go
@@ -13,6 +13,7 @@ limitations under the License.
 package types
 
 import (
+	"encoding/json"
 	"fmt"
 
 	"github.com/pkg/errors"
@@ -42,6 +43,15 @@ type PodResources struct {
 	SafeToEvict    bool
 	OOMKilled      bool
 	recomendations *Recomendations
+}
+
+func (r *PodResources) String() string {
+	result, err := json.Marshal(r)
+	if err != nil {
+		return err.Error()
+	}
+
+	return string(result)
 }
 
 func (r *PodResources) SetRecomendation(recomendations *Recomendations) {
@@ -84,7 +94,7 @@ func (r *PodResources) GetFormattedResources() *PodResources {
 	}
 
 	if r.recomendations.OOMKilled || r.OOMKilled {
-		result.MemoryLimit = fmt.Sprintf("%s OOMKilled", result.MemoryLimit)
+		result.OOMKilled = true
 	}
 
 	return &result


### PR DESCRIPTION
add flag `-OOMKilled` to show only pods with OOMKilled termination reason

Signed-off-by: Maksim Paskal <paskal.maksim@gmail.com>